### PR TITLE
Align cycle day text size and style date edit dialog

### DIFF
--- a/app/src/main/java/com/algoritmika/prapp/MainActivity.kt
+++ b/app/src/main/java/com/algoritmika/prapp/MainActivity.kt
@@ -55,6 +55,7 @@ import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.util.Calendar
+import java.util.Locale
 
 
 class MainActivity : ComponentActivity() {
@@ -414,11 +415,17 @@ fun DateEditDialog(
     val context = LocalContext.current
     var startDate by remember { mutableStateOf(initialStart) }
     var endDate by remember { mutableStateOf(initialEnd) }
-    val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
+    val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy", Locale.ENGLISH)
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Изменить даты") },
+        title = {
+            Text(
+                text = "Edit Dates",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+        },
         text = {
             Column {
                 Button(onClick = {
@@ -432,7 +439,7 @@ fun DateEditDialog(
                         startDate.dayOfMonth
                     ).show()
                 }) {
-                    Text("Начало: ${startDate.format(formatter)}")
+                    Text("Start: ${startDate.format(formatter)}")
                 }
 
                 Button(onClick = {
@@ -446,20 +453,22 @@ fun DateEditDialog(
                         endDate.dayOfMonth
                     ).show()
                 }) {
-                    Text("Конец: ${endDate.format(formatter)}")
+                    Text("End: ${endDate.format(formatter)}")
                 }
             }
         },
         confirmButton = {
             Button(onClick = { onConfirm(startDate, endDate) }) {
-                Text("Сохранить")
+                Text("Save")
             }
         },
         dismissButton = {
             Button(onClick = onDismiss) {
-                Text("Отмена")
+                Text("Cancel")
             }
-        }
+        },
+        shape = RoundedCornerShape(12.dp),
+        containerColor = MaterialTheme.colorScheme.surface
     )
 }
 

--- a/app/src/main/java/com/algoritmika/prapp/UIComponents.kt
+++ b/app/src/main/java/com/algoritmika/prapp/UIComponents.kt
@@ -56,7 +56,7 @@ fun CycleInfo(ranges: List<ClosedRange<LocalDate>>) {
                     )
                     Text(
                         text = "Day of Cycle",
-                        style = MaterialTheme.typography.labelSmall,
+                        style = MaterialTheme.typography.titleMedium,
                         color = MaterialTheme.colorScheme.secondary
                     )
                 }


### PR DESCRIPTION
## Summary
- Match "Day of Cycle" label typography with month headers
- Restyle and translate date editing dialog to English with app theme

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dca956ea48320b457f5e7ceb8e4ad