### PR TITLE
Revamp Edit Dates dialog design

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.material:material-icons-extended")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/algoritmika/prapp/MainActivity.kt
+++ b/app/src/main/java/com/algoritmika/prapp/MainActivity.kt
@@ -18,14 +18,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -33,8 +35,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -48,6 +53,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
 import com.algoritmika.prapp.ui.theme.PrAppTheme
 import java.io.File
 import java.time.LocalDate
@@ -417,59 +423,82 @@ fun DateEditDialog(
     var endDate by remember { mutableStateOf(initialEnd) }
     val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy", Locale.ENGLISH)
 
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = {
-            Text(
-                text = "Edit Dates",
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.primary
-            )
-        },
-        text = {
-            Column {
-                Button(onClick = {
-                    DatePickerDialog(
-                        context,
-                        { _, year, month, day ->
-                            startDate = LocalDate.of(year, month + 1, day)
-                        },
-                        startDate.year,
-                        startDate.monthValue - 1,
-                        startDate.dayOfMonth
-                    ).show()
-                }) {
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(
+            shape = RoundedCornerShape(24.dp),
+            color = MaterialTheme.colorScheme.surface,
+            tonalElevation = 4.dp,
+            shadowElevation = 4.dp
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Text(
+                    text = "Edit Dates",
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.primary
+                )
+                OutlinedButton(
+                    onClick = {
+                        DatePickerDialog(
+                            context,
+                            { _, year, month, day ->
+                                startDate = LocalDate.of(year, month + 1, day)
+                            },
+                            startDate.year,
+                            startDate.monthValue - 1,
+                            startDate.dayOfMonth
+                        ).show()
+                    },
+                    shape = RoundedCornerShape(50),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(Icons.Default.CalendarToday, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
                     Text("Start: ${startDate.format(formatter)}")
                 }
-
-                Button(onClick = {
-                    DatePickerDialog(
-                        context,
-                        { _, year, month, day ->
-                            endDate = LocalDate.of(year, month + 1, day)
-                        },
-                        endDate.year,
-                        endDate.monthValue - 1,
-                        endDate.dayOfMonth
-                    ).show()
-                }) {
+                OutlinedButton(
+                    onClick = {
+                        DatePickerDialog(
+                            context,
+                            { _, year, month, day ->
+                                endDate = LocalDate.of(year, month + 1, day)
+                            },
+                            endDate.year,
+                            endDate.monthValue - 1,
+                            endDate.dayOfMonth
+                        ).show()
+                    },
+                    shape = RoundedCornerShape(50),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(Icons.Default.CalendarToday, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
                     Text("End: ${endDate.format(formatter)}")
                 }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    TextButton(
+                        onClick = onDismiss,
+                        colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.secondary)
+                    ) {
+                        Text("Cancel")
+                    }
+                    Spacer(Modifier.width(12.dp))
+                    Button(
+                        onClick = { onConfirm(startDate, endDate) },
+                        shape = RoundedCornerShape(50)
+                    ) {
+                        Text("Save")
+                    }
+                }
             }
-        },
-        confirmButton = {
-            Button(onClick = { onConfirm(startDate, endDate) }) {
-                Text("Save")
-            }
-        },
-        dismissButton = {
-            Button(onClick = onDismiss) {
-                Text("Cancel")
-            }
-        },
-        shape = RoundedCornerShape(12.dp),
-        containerColor = MaterialTheme.colorScheme.surface
-    )
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/algoritmika/prapp/ui/theme/Theme.kt
+++ b/app/src/main/java/com/algoritmika/prapp/ui/theme/Theme.kt
@@ -15,7 +15,8 @@ private val DarkColorScheme = darkColorScheme(
     background = DarkBackground,
     onBackground = Color.White,
     surface = DarkCard,
-    onSurface = Color.White
+    onSurface = Color.White,
+    scrim = DarkBackground.copy(alpha = 0.6f)
 )
 
 private val LightColorScheme = lightColorScheme(
@@ -26,7 +27,8 @@ private val LightColorScheme = lightColorScheme(
     background = BeigeBackground,
     onBackground = DarkText,
     surface = Color.White,
-    onSurface = DarkText
+    onSurface = DarkText,
+    scrim = DarkBackground.copy(alpha = 0.6f)
 )
 
 @Composable


### PR DESCRIPTION
## Summary
- Style the Edit Dates dialog with warm 24dp surfaced card, pill selectors with calendar icons, and accented actions
- Customize theme scrim color for a soft dark navy overlay
- Add material-icons-extended dependency for calendar icon

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dd0f671e48320b8aca448c8c42513