### PR TITLE
Add settings for prediction window and cycle duration

### DIFF
--- a/app/src/main/java/com/algoritmika/prapp/model.kt
+++ b/app/src/main/java/com/algoritmika/prapp/model.kt
@@ -35,12 +35,13 @@ fun predictNextPeriodsMovingAverage(startDates: List<LocalDate>, windowSize: Int
 
 fun predictFutureRanges(
     pastRanges: List<ClosedRange<LocalDate>>,
-    windowSize: Int = 3
+    windowSize: Int = 3,
+    periodDuration: Int = 4
 ): List<ClosedRange<LocalDate>> {
     val startDates = pastRanges.map { it.start }
     val predictedStarts = predictNextPeriodsMovingAverage(startDates, windowSize)
     return predictedStarts.map { startDate ->
-        startDate..startDate.plusDays(4)
+        startDate..startDate.plusDays(periodDuration.toLong())
     }
 }
 


### PR DESCRIPTION
## Summary
- Add SettingsScreen with comboboxes for prediction window and standard period duration
- Store selected values in SharedPreferences and apply to prediction logic
- Extend prediction functions to accept window size and duration parameters

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ddd1a7e3c832083a7dc0ebe73ec6e