### PR TITLE
Add language selection and localization

### DIFF
--- a/app/src/main/java/com/algoritmika/prapp/FileEditor.kt
+++ b/app/src/main/java/com/algoritmika/prapp/FileEditor.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
+import androidx.compose.ui.res.stringResource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -42,7 +43,7 @@ fun FileEditorScreen(
 
     Column(modifier = Modifier.padding(16.dp)) {
         Text(
-            text = "Edit date_ranges.txt",
+            text = stringResource(R.string.edit_file_title),
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.primary
         )
@@ -97,12 +98,12 @@ fun FileEditorScreen(
                     }
                     error = null
                 } else {
-                    error = "File contains lines in wrong format!"
+                    error = context.getString(R.string.wrong_format_error)
                 }
             },
             modifier = Modifier.fillMaxWidth()
         ) {
-            Text("Save")
+            Text(stringResource(R.string.save))
         }
     }
 }

--- a/app/src/main/java/com/algoritmika/prapp/UIComponents.kt
+++ b/app/src/main/java/com/algoritmika/prapp/UIComponents.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.ui.res.stringResource
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -55,7 +56,7 @@ fun CycleInfo(ranges: List<ClosedRange<LocalDate>>) {
                         color = MaterialTheme.colorScheme.onPrimary
                     )
                     Text(
-                        text = "Day of Cycle",
+                        text = stringResource(R.string.day_of_cycle),
                         style = MaterialTheme.typography.titleMedium,
                         color = MaterialTheme.colorScheme.secondary
                     )

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1,0 +1,24 @@
+<resources>
+    <string name="app_name">PrApp</string>
+    <string name="prediction_window">Prognosevindu</string>
+    <string name="standard_duration">Standard varighet</string>
+    <string name="apply_settings">Bruk innstillinger</string>
+    <string name="calendar">Kalender</string>
+    <string name="file">Fil</string>
+    <string name="settings">Innstillinger</string>
+    <string name="edit_dates">Rediger datoer</string>
+    <string name="start_label">Start: %s</string>
+    <string name="end_label">Slutt: %s</string>
+    <string name="predicted_values_cannot_be_changed">Predikerte verdier kan ikke endres</string>
+    <string name="cancel">Avbryt</string>
+    <string name="save">Lagre</string>
+    <string name="edit_file_title">Rediger date_ranges.txt</string>
+    <string name="wrong_format_error">Filen inneholder linjer i feil format!</string>
+    <string name="day_of_cycle">Syklusdag</string>
+    <string name="language">Språk</string>
+    <string name="lang_english">Engelsk</string>
+    <string name="lang_russian">Russisk</string>
+    <string name="lang_ukrainian">Ukrainsk</string>
+    <string name="lang_norwegian">Norsk</string>
+    <string name="change_text">Endre tekst</string>
+</resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,0 +1,24 @@
+<resources>
+    <string name="app_name">PrApp</string>
+    <string name="prediction_window">Окно предсказания</string>
+    <string name="standard_duration">Стандартная длительность</string>
+    <string name="apply_settings">Применить настройки</string>
+    <string name="calendar">Календарь</string>
+    <string name="file">Файл</string>
+    <string name="settings">Настройки</string>
+    <string name="edit_dates">Редактировать даты</string>
+    <string name="start_label">Начало: %s</string>
+    <string name="end_label">Конец: %s</string>
+    <string name="predicted_values_cannot_be_changed">Предсказанные значения нельзя изменить</string>
+    <string name="cancel">Отмена</string>
+    <string name="save">Сохранить</string>
+    <string name="edit_file_title">Редактировать date_ranges.txt</string>
+    <string name="wrong_format_error">Файл содержит строки в неверном формате!</string>
+    <string name="day_of_cycle">День цикла</string>
+    <string name="language">Язык</string>
+    <string name="lang_english">Английский</string>
+    <string name="lang_russian">Русский</string>
+    <string name="lang_ukrainian">Украинский</string>
+    <string name="lang_norwegian">Норвежский</string>
+    <string name="change_text">Изменить текст</string>
+</resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1,0 +1,24 @@
+<resources>
+    <string name="app_name">PrApp</string>
+    <string name="prediction_window">Вікно прогнозу</string>
+    <string name="standard_duration">Стандартна тривалість</string>
+    <string name="apply_settings">Застосувати налаштування</string>
+    <string name="calendar">Календар</string>
+    <string name="file">Файл</string>
+    <string name="settings">Налаштування</string>
+    <string name="edit_dates">Редагувати дати</string>
+    <string name="start_label">Початок: %s</string>
+    <string name="end_label">Кінець: %s</string>
+    <string name="predicted_values_cannot_be_changed">Прогнозовані значення не можна змінити</string>
+    <string name="cancel">Скасувати</string>
+    <string name="save">Зберегти</string>
+    <string name="edit_file_title">Редагувати date_ranges.txt</string>
+    <string name="wrong_format_error">Файл містить рядки у неправильному форматі!</string>
+    <string name="day_of_cycle">День циклу</string>
+    <string name="language">Мова</string>
+    <string name="lang_english">Англійська</string>
+    <string name="lang_russian">Російська</string>
+    <string name="lang_ukrainian">Українська</string>
+    <string name="lang_norwegian">Норвезька</string>
+    <string name="change_text">Змінити текст</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,24 @@
 <resources>
     <string name="app_name">PrApp</string>
+    <string name="prediction_window">Prediction window</string>
+    <string name="standard_duration">Standard duration</string>
+    <string name="apply_settings">Apply Settings</string>
+    <string name="calendar">Calendar</string>
+    <string name="file">File</string>
+    <string name="settings">Settings</string>
+    <string name="edit_dates">Edit Dates</string>
+    <string name="start_label">Start: %s</string>
+    <string name="end_label">End: %s</string>
+    <string name="predicted_values_cannot_be_changed">Predicted values cannot be changed</string>
+    <string name="cancel">Cancel</string>
+    <string name="save">Save</string>
+    <string name="edit_file_title">Edit date_ranges.txt</string>
+    <string name="wrong_format_error">File contains lines in wrong format!</string>
+    <string name="day_of_cycle">Day of Cycle</string>
+    <string name="language">Language</string>
+    <string name="lang_english">English</string>
+    <string name="lang_russian">Russian</string>
+    <string name="lang_ukrainian">Ukrainian</string>
+    <string name="lang_norwegian">Norwegian</string>
+    <string name="change_text">Change text</string>
 </resources>


### PR DESCRIPTION
## Summary
- add language dropdown in settings and locale switching logic
- localize UI strings and provide translations for Russian, Ukrainian, and Norwegian Bokmål

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e4165cd38832090345578638c5352